### PR TITLE
Tweaks for making it work on windows

### DIFF
--- a/generator/Doxyfile
+++ b/generator/Doxyfile
@@ -124,7 +124,7 @@ ENABLE_PREPROCESSING   = YES
 MACRO_EXPANSION        = YES
 EXPAND_ONLY_PREDEF     = YES
 PREDEFINED             = URHO3D_OBJECT(typeName,baseTypeName)=public: URHO3D_API:= URHO3D_EVENT(a,b):=if(0) URHO3D_PARAM(a,b):=((void)0) URHO3D_OPENGL
-EXPAND_AS_DEFINED      = URHO3D_FLAGSET
+EXPAND_AS_DEFINED      = URHO3D_FLAGSET URHO3D_AUTOMATIC_FLAGSET
 # EXPAND_AS_DEFINED      = URHO3D_FLAGSET URHO3D_EVENT URHO3D_PARAM
 # PREDEFINED             =  URHO3D_OBJECT(typeName, baseTypeName)=public:  using ClassName = typeName;  using BaseClassName = baseTypeName;  virtual Urho3D::StringHash GetType() const override { return GetTypeInfoStatic()->GetType(); }  virtual const Urho3D::String& GetTypeName() const override { return GetTypeInfoStatic()->GetTypeName(); }  virtual const Urho3D::TypeInfo* GetTypeInfo() const override { return GetTypeInfoStatic(); }  static Urho3D::StringHash GetTypeStatic() { return GetTypeInfoStatic()->GetType(); }  static const Urho3D::String& GetTypeNameStatic() { return GetTypeInfoStatic()->GetTypeName(); }  static const Urho3D::TypeInfo* GetTypeInfoStatic() { static const Urho3D::TypeInfo typeInfoStatic(#typeName, BaseClassName::GetTypeInfoStatic()); return &typeInfoStatic; }
 

--- a/generator/generate-bindings.py
+++ b/generator/generate-bindings.py
@@ -1485,6 +1485,8 @@ void bindClass_Urho3D_ALL(sol::state_view& lua)
 
 ''')
 
+genPath = path.join("generated", "")
+syncGenPath = path.join('synced-generated', "")
 
 for f in glob('generated/**',recursive=True):
     if not path.isfile(f):
@@ -1492,12 +1494,12 @@ for f in glob('generated/**',recursive=True):
     with open(f) as r:
         data = r.read()
     try:
-        with open(f.replace('generated/','synced-generated/')) as w:
+        with open(f.replace(genPath,syncGenPath)) as w:
             old = w.read()
     except FileNotFoundError:
         old = None
     if data != old:
-        with open(f.replace('generated/','synced-generated/'),'w') as w:
+        with open(f.replace(genPath,syncGenPath),'w') as w:
             w.write(data)
         print('++Updated',f)
     else:
@@ -1506,7 +1508,7 @@ for f in glob('generated/**',recursive=True):
 for f in glob('synced-generated/**',recursive=True):
     if not path.isfile(f):
         continue
-    if not os.path.exists(f.replace('synced-generated/','generated/')):
+    if not os.path.exists(f.replace(syncGenPath,genPath)):
         print('--Removed',f)
         os.remove(f)
             

--- a/generator/generate-bindings.py
+++ b/generator/generate-bindings.py
@@ -271,6 +271,9 @@ auto type = lua.new_usertype<{scoped}>( "{name}"
 '''.format(**kwargs)
 
 def bind_member(name,binding,comment=False):
+    if name == '':
+        return ''
+
     if comment:
         return f'''
 # if 0 // SKIPPED

--- a/generator/generate-bindings.py
+++ b/generator/generate-bindings.py
@@ -1025,6 +1025,12 @@ class Class(auto_repr):
             if self.filename == h or self.filename.endswith('/'+h):
                 includes += '\n' + include_file_additions[f]
                 print('    INCLUDE',f,self.filename,include_file_additions[f])
+                
+        for f in extra_file_additions:
+            h = f.replace('.cpp','.h')
+            if self.filename == h or self.filename.endswith('/'+h):
+                includes += '\n\n' + extra_file_additions[f]
+                print('    INCLUDE',f,self.filename,extra_file_additions[f])
         
         
         # Always need the casters to be defined

--- a/generator/generate-bindings.py
+++ b/generator/generate-bindings.py
@@ -1030,7 +1030,7 @@ class Class(auto_repr):
             h = f.replace('.cpp','.h')
             if self.filename == h or self.filename.endswith('/'+h):
                 includes += '\n\n' + extra_file_additions[f]
-                print('    INCLUDE',f,self.filename,extra_file_additions[f])
+                print('    EXTRA',f,self.filename,extra_file_additions[f])
         
         
         # Always need the casters to be defined

--- a/generator/generate-bindings.py
+++ b/generator/generate-bindings.py
@@ -68,6 +68,13 @@ include_file_additions = {
     'Graphics.cpp' : '#include <SDL/SDL_video.h>\n#include <Urho3D/Graphics/GraphicsImpl.h>',
 }
 
+# additions for stuff like platform-dependent quirks, or anything else
+extra_file_additions = {
+    'Connection.cpp' : '''#ifdef SendMessage
+#undef SendMessage
+#endif''',
+}
+
 forbid_files = [
     'Urho2D/SpriterData2D.h',
     'Urho2D/SpriterInstance2D.h',

--- a/generator/generate-bindings.py
+++ b/generator/generate-bindings.py
@@ -630,7 +630,7 @@ class Function(auto_repr):
             return args
     def get_specific(self):
         if self.ret.is_unshared_ref_counted('Urho3D::Object'):
-            argdefs = self.argstring[1:self.argstring.rfind(')')]
+            argdefs = re.sub(r'=[^,]+(?=,?)', '', self.argstring[1:self.argstring.rfind(')')])
             if self.Class:
                 if argdefs:
                     argdefs = ', ' + argdefs


### PR DESCRIPTION
Here's the PR!

- I added URHO3D_AUTOMATIC_FLAGSET to the doxygen EXPAND_AS_DEFINED list because it was appearing in the c++ output for me, preventing the code from compiling
- Added the "extra" #undef stuff for Connection
- I tried to replace some uses of forward slashes by path.join, in order to, hopefully, work on both platforms

There are some local changes I haven't added to the repo, like, in lines ~1205 and ~1363 of the generator, there are those `h=path.join('generated',f'BindFunctions_{nsu}.h')`, which get added directly to the headers in the next line. I had to remove the "generated/" part of the include to make them work here.